### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/RedEye1605/Leksara/security/code-scanning/1](https://github.com/RedEye1605/Leksara/security/code-scanning/1)

To fix the issue, you should add an explicit `permissions:` block as close to the top of the workflow file as possible. If the entire workflow requires only read access to repository contents, you should set `permissions: contents: read` before the jobs block (at the root level). If any job or step requires additional write permissions, you could elevate only for that job by placing the `permissions:` block inside the job. For this workflow, which only installs dependencies, lints, and runs tests, only reading repository contents is required; no writes (such as opening PRs or comments) are performed. Therefore, add the following to the beginning of the workflow file, just after the workflow name (`name:`):

```yaml
permissions:
  contents: read
```

This should be added between lines 4 (name) and 5 (on) of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
